### PR TITLE
+semver:minor Adding a new has-changes output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
 
       - name: Update readme with latest version
         # You may also reference just the major or major.minor version.
-        uses: im-open/update-action-version-in-file@v1.0.1
+        uses: im-open/update-action-version-in-file@v1.1.0
         id: version-readme
         with:
           file-to-update: './README.md'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2442,12 +2442,19 @@ var versionPrefixInput = core.getInput('version-prefix', requiredArgOptions);
 var versionPrefix = versionPrefixInput == 'none' ? '' : versionPrefixInput;
 var updatedVersion = core.getInput('updated-version', requiredArgOptions);
 var saveFile = core.getBooleanInput('save-file', requiredArgOptions);
-var rawFileContent = fs.readFileSync(fileName, 'utf8');
+var originalFileContent = fs.readFileSync(fileName, 'utf8');
 var regexString = `${actionName}@${versionPrefix}([0-9]+)(.[0-9]+)*(.[0-9]+)*`;
 var actionVersionRegex = new RegExp(regexString, 'ig');
 var replacementValue = `${actionName}@${updatedVersion}`;
-var updatedFileContent = rawFileContent.replace(actionVersionRegex, replacementValue);
-if (saveFile) {
-  fs.writeFileSync(fileName, updatedFileContent);
+var updatedFileContent = originalFileContent.replace(actionVersionRegex, replacementValue);
+var hasChanges = updatedFileContent != originalFileContent;
+if (hasChanges) {
+  core.info(`Version changes were detected in ${fileName}.`);
+  if (saveFile) {
+    fs.writeFileSync(fileName, updatedFileContent);
+  }
+} else {
+  core.info(`No version changes were detected in ${fileName}.`);
 }
+core.setOutput('has-changes', hasChanges);
 core.setOutput('updated-content', updatedFileContent);

--- a/src/main.js
+++ b/src/main.js
@@ -17,15 +17,23 @@ const versionPrefix = versionPrefixInput == 'none' ? '' : versionPrefixInput;
 const updatedVersion = core.getInput('updated-version', requiredArgOptions);
 const saveFile = core.getBooleanInput('save-file', requiredArgOptions);
 
-const rawFileContent = fs.readFileSync(fileName, 'utf8');
+const originalFileContent = fs.readFileSync(fileName, 'utf8');
 const regexString = `${actionName}@${versionPrefix}([0-9]+)(\.[0-9]+)*(\.[0-9]+)*`;
 const actionVersionRegex = new RegExp(regexString, 'ig');
 
 const replacementValue = `${actionName}@${updatedVersion}`;
 
-const updatedFileContent = rawFileContent.replace(actionVersionRegex, replacementValue);
-if (saveFile) {
-  fs.writeFileSync(fileName, updatedFileContent);
+const updatedFileContent = originalFileContent.replace(actionVersionRegex, replacementValue);
+const hasChanges = updatedFileContent != originalFileContent;
+
+if (hasChanges) {
+  core.info(`Version changes were detected in ${fileName}.`);
+  if (saveFile) {
+    fs.writeFileSync(fileName, updatedFileContent);
+  }
+} else {
+  core.info(`No version changes were detected in ${fileName}.`);
 }
 
+core.setOutput('has-changes', hasChanges);
 core.setOutput('updated-content', updatedFileContent);


### PR DESCRIPTION
# Summary of PR changes

- Add an additional output for has-changes

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
