### PR TITLE
ARCH-1919 - Transfer to Infra-Purple

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @im-open/swat
+* @im-open/infra-purple

--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
           fetch-depth: 0
 
       - name: Check for code changes to the action source code
@@ -58,7 +57,7 @@ jobs:
       - name: Get the next version for the repo
         if: steps.source-code.outputs.HAS_CHANGES == 'true'
         id: version
-        uses: im-open/git-version-lite@v2
+        uses: im-open/git-version-lite@transfer
 
       - name: The next action version will be - ${{ steps.version.outputs.NEXT_VERSION || 'N/A'}}
         if: steps.source-code.outputs.HAS_CHANGES == 'true'

--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -22,6 +22,10 @@ on:
   #   we can also use that to require all branches be up to date before they are merged.
 
 jobs:
+  # Normally the setup job and the build-and-review-pr job would be performed
+  # in a resuable workflow.  However, this action is used in that reusable workflow
+  # so it contains its own copy of the build functionality.
+  # reusable workflow: im-open/.github/.github/workflows/reusable-build-and-review-pr.yml
   setup:
     runs-on: ubuntu-latest
     outputs:
@@ -201,3 +205,80 @@ jobs:
               .addRaw(instructionsWithLinks)
               .write();
             core.setFailed(instructions);
+
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      PRODUCTION_READY_TAG: 'v1.1.3'
+      PRE_RELEASE_TAG: 'v1.0.2'
+      DRAFT_RELEASE_TAG: 'v1.0.1'
+      NONEXISTENT_RELEASE_TAG: 'v304.973.444'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      #--------------------------------------
+      # FILE HAS CHANGES
+      #--------------------------------------
+      - name: '-------------------------------------------------------------------------------------------------------'
+        run: echo ""
+      - name: When updating a file with a new action version
+        uses: ./
+        if: always()
+        id: changes
+        with:
+          file-to-update: ./test/file-to-update.md
+          action-name: im-open/update-action-version-in-file
+          version-prefix: p
+          updated-version: v1.0.0
+          
+      - name: Then the outcome should be success
+        if: always()
+        run: ./test/assert-values-match.sh --name "step outcome" --expected "success" --actual "${{ steps.changes.outcome }}"
+
+      - name: And the has-changes output should be true
+        if: always()
+        run: ./test/assert-values-match.sh --name "has-changes" --expected "true" --actual "${{ steps.changes.outputs.has-changes }}"
+      
+      - name: And the updated-content output should have updated action versions
+        if: always()
+        run: |
+          expectedContent=$(cat ./test/expected-output.md)
+          ./test/assert-values-match.sh --name "updated-content" --expected "$expectedContent" --actual "${{ steps.changes.outputs.updated-content }}"
+      
+
+      #--------------------------------------
+      # FILE HAS NO CHANGES
+      #--------------------------------------
+      - name: '-------------------------------------------------------------------------------------------------------'
+        run: echo ""
+      - name: When updating a file with a new action version
+        uses: ./
+        if: always()
+        id: no-changes
+        with:
+          file-to-update: ./test/file-to-update.md
+          action-name: im-open/different-action-version
+          version-prefix: v
+          updated-version: v1.0.0
+          
+      - name: Then the outcome should be success
+        if: always()
+        run: ./test/assert-values-match.sh --name "step outcome" --expected "success" --actual "${{ steps.no-changes.outcome }}"
+
+      - name: And the has-changes output should be false
+        if: always()
+        run: ./test/assert-values-match.sh --name "has-changes" --expected "false" --actual "${{ steps.no-changes.outputs.has-changes }}"
+      
+      - name: And the updated-content output should be the original content
+        if: always()
+        run: |
+          expectedContent=$(cat ./test/file-to-update.md)
+          ./test/assert-values-match.sh --name "updated-content" --expected "$expectedContent" --actual "${{ steps.no-changes.outputs.updated-content }}"
+
+      - name: '-------------------------------------------------------------------------------------------------------'
+        run: echo ""
+     
+      
+      

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This action looks for usages of a specified GitHub action so it can update each 
 | `action-name`     | true        |         | The name of the action that will be updated in the specified file. Format should be `org/repo` and any nested directories if applicable.</br>&nbsp;&nbsp;• `im-open/is-actor-authorized`</br>&nbsp;&nbsp;• `actions/aws/ec2` |
 | `version-prefix`  | false       | `v`     | The prefix the action uses in its versions, if applicable.                                                                                                                                                                   |
 | `updated-version` | true        |         | The new action version to replace other instances with in the specified file.                                                                                                                                                |
-| `save-file`       | false       | true    | Flag indicating whether the changes to the specified file should be saved. <br/>Accepts: `true or false`.                                                                                                                    |
 
 ## Outputs and Environment Variables
 
@@ -81,7 +80,7 @@ jobs:
 
       - name: Update readme with latest version
         # You may also reference just the major or major.minor version.
-        uses: im-open/update-action-version-in-file@v1.1.1
+        uses: im-open/update-action-version-in-file@v2.0.0
         id: version-readme
         with:
           file-to-update: './README.md'

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,6 @@ inputs:
   updated-version:
     description: 'The new action version to replace other instances with in the specified file.'
     required: true
-  save-file:
-    description: 'Flag indicating whether the changes to the specified file should be saved.  Accepts: `true|false`.'
-    default: 'true'
 
 outputs:
   updated-content:

--- a/dist/index.js
+++ b/dist/index.js
@@ -2441,7 +2441,6 @@ var actionName = core.getInput('action-name', requiredArgOptions);
 var versionPrefixInput = core.getInput('version-prefix', requiredArgOptions);
 var versionPrefix = versionPrefixInput == 'none' ? '' : versionPrefixInput;
 var updatedVersion = core.getInput('updated-version', requiredArgOptions);
-var saveFile = core.getBooleanInput('save-file', requiredArgOptions);
 var originalFileContent = fs.readFileSync(fileName, 'utf8');
 var regexString = `${actionName}@${versionPrefix}([0-9]+)(.[0-9]+)*(.[0-9]+)*`;
 var actionVersionRegex = new RegExp(regexString, 'ig');
@@ -2450,9 +2449,6 @@ var updatedFileContent = originalFileContent.replace(actionVersionRegex, replace
 var hasChanges = updatedFileContent != originalFileContent;
 if (hasChanges) {
   core.info(`Version changes were detected in ${fileName}.`);
-  if (saveFile) {
-    fs.writeFileSync(fileName, updatedFileContent);
-  }
 } else {
   core.info(`No version changes were detected in ${fileName}.`);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,6 @@ const versionPrefixInput = core.getInput('version-prefix', requiredArgOptions);
 const versionPrefix = versionPrefixInput == 'none' ? '' : versionPrefixInput;
 
 const updatedVersion = core.getInput('updated-version', requiredArgOptions);
-const saveFile = core.getBooleanInput('save-file', requiredArgOptions);
 
 const originalFileContent = fs.readFileSync(fileName, 'utf8');
 const regexString = `${actionName}@${versionPrefix}([0-9]+)(\.[0-9]+)*(\.[0-9]+)*`;
@@ -28,9 +27,6 @@ const hasChanges = updatedFileContent != originalFileContent;
 
 if (hasChanges) {
   core.info(`Version changes were detected in ${fileName}.`);
-  if (saveFile) {
-    fs.writeFileSync(fileName, updatedFileContent);
-  }
 } else {
   core.info(`No version changes were detected in ${fileName}.`);
 }

--- a/test/assert-values-match.sh
+++ b/test/assert-values-match.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+name=''
+expectedValue=''
+actualValue=''
+
+for arg in "$@"; do
+    case $arg in
+    --name)
+        name=$2
+        shift # Remove argument --name from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    --expected)
+        expectedValue=$2
+        shift # Remove argument --expected from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    --actual)
+        actualValue=$2
+        shift # Remove argument --actual from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    
+    esac
+done
+
+echo "
+Expected $name: '$expectedValue'"
+echo "Actual $name:   '$actualValue'"
+
+if [ "$expectedValue" != "$actualValue" ]; then
+  echo "The expected $name does not match the actual $name."  
+  exit 1
+else 
+  echo "The expected and actual $name values match."
+fi

--- a/test/expected-output.md
+++ b/test/expected-output.md
@@ -1,0 +1,9 @@
+# Action Versions
+
+im-open/update-action-version-in-file@v1.0.0
+
+im-open/update-action-version-in-file@v1.0.0
+
+im-open/update-action-version-in-file@v1.0.0
+
+im-open/update-action-version-in-file@v1.0.0

--- a/test/file-to-update.md
+++ b/test/file-to-update.md
@@ -1,0 +1,9 @@
+# Action Versions
+
+im-open/update-action-version-in-file@p0
+
+im-open/update-action-version-in-file@p1.1
+
+im-open/update-action-version-in-file@p22.22.22
+
+im-open/update-action-version-in-file@p333.333.333.333


### PR DESCRIPTION
BREAKING CHANGES
+semver:major
+semver:breaking

# Summary of PR changes

- Update CODEOWNERS
- Add tests to build-and-review-pr.yml
- Remove save-file argument.  It was not used in any IM repos. +semver:major


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
